### PR TITLE
Update osmap.yaml for ubuntu > 22

### DIFF
--- a/salt/osmap.yaml
+++ b/salt/osmap.yaml
@@ -13,6 +13,7 @@
 {%- set osmajorrelease = salt['grains.get']('osmajorrelease', osrelease)|string %}
 {%- set oscodename = salt['grains.get']('oscodename') %}
 {%- set os_family_lower =  salt['grains.get']('os_family')|lower %}
+{%- set osarch_lower =  salt['grains.get']('osarch_lower')|lower %}
 {%- set salt_repo = salt['pillar.get']('salt:repo', 'https://repo.saltproject.io') %}
 
 Fedora:
@@ -25,10 +26,17 @@ Amazon:
   key_url: '{{ salt_repo }}/{{ py_ver_repr or 'yum' }}/amazon/2/$basearch/{{ salt_release }}/SALTSTACK-GPG-KEY.pub'
 
 Ubuntu:
+  {% if os_lower == 'ubuntu' and osmajorrelease >= '22' -%}
+  pkgrepo: 'deb [signed-by=/usr/share/keyrings/salt-archive-keyring.gpg arch={{ osarch_lower }}] {{ salt_repo }}/salt/{{ py_ver_repr }}/{{ os_lower }}/{{ osrelease }}/{{ osarch_lower }}/{{ salt_release }} {{ oscodename }} main'
+  pkgrepo_keyring:  '{{ salt_repo }}/salt/{{ py_ver_repr or 'py3' }}/{{ os_lower }}/{{ osrelease }}/{{ osarch_lower }}/SALT-PROJECT-GPG-PUBKEY-2023.gpg'
+  key_url:  '{{ salt_repo }}/{{ py_ver_repr or 'py3' }}/{{ os_lower }}/{{ osrelease }}/{{ osarch_lower }}/{{ salt_release }}/SALT-PROJECT-GPG-PUBKEY-2023.pub'
+  pkgrepo_keyring_hash: sha256=c6f6cbcd96fdb130b1dde8dcfc05d46a3a3f322ff0514f98e2e6473896243472
+  {%- else -%}
   pkgrepo: 'deb [signed-by=/usr/share/keyrings/salt-archive-keyring.gpg arch=amd64] {{ salt_repo }}/{{ py_ver_repr or 'apt' }}/{{ os_lower }}/{{ osrelease }}/amd64/{{ salt_release }} {{ oscodename }} main'
   pkgrepo_keyring: '{{ salt_repo }}/{{ py_ver_repr or 'apt' }}/{{ os_lower }}/{{ osrelease }}/amd64/{{ salt_release }}/salt-archive-keyring.gpg'
   pkgrepo_keyring_hash: sha256=ea38e0cdbd8dc53e1af154a8d711a2a321a69f81188062dc5cde9d54df2b8c47
   key_url: '{{ salt_repo }}/{{ py_ver_repr or 'apt' }}/{{ os_lower }}/{{ osrelease }}/amd64/{{ salt_release }}/SALTSTACK-GPG-KEY.pub'
+  {%- endif %}
   pygit2: python-pygit2
   gitfs:
     pygit2:


### PR DESCRIPTION
For Ubuntu >22 update OS map to assume python3 as there is no python2 support.